### PR TITLE
[WIP] Use configs from deploy.js as blueprints

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,19 @@ var CoreObject     = require('core-object');
 var chalk = require('chalk');
 var blue  = chalk.blue;
 
+function configurationFactory(configurationBlueprint) {
+  if (!configurationBlueprint) { return; }
+
+  var config = {};
+  var keys = Object.keys(configurationBlueprint);
+
+  keys.forEach(function(key) {
+    config[key] = configurationBlueprint[key];
+  });
+
+  return config;
+}
+
 var DeployPluginBase = CoreObject.extend({
   context: null,
   ui: null,
@@ -12,7 +25,7 @@ var DeployPluginBase = CoreObject.extend({
     this.context = context;
     this.ui = context.ui;
     this.project = context.project;
-    context.config[this.name] = context.config[this.name] || {};
+    context.config[this.name] = configurationFactory(context.config[this.name]) || {};
     this.pluginConfig = context.config[this.name];
   },
   configure: function(/* context */) {


### PR DESCRIPTION
This makes it possible to reuse objects accross several
plugin configs without the plugins' configure hooks destroying
the configuration that the users have passed in `deploy.js`

It wasn't possible to do things like this for example:

``` javascript
// config/deploy.js

module.exports = function(deployTarget) {
  var s3Credentials = {
    accessKeyId: '...',
    secretAccessKey: '...',
    bucket: '...',
    region: 'us-east-1'
  };
  var ENV = {
    build: { environment: deployTarget },
    s3: s3Credentials,
    's3-index': s3Credentials
  };

  return ENV;
};
```

This issue came up in https://github.com/ember-cli-deploy/ember-cli-deploy-s3-index/issues/21

I am not sure if this is the best way to do this. As @achambers pointed out using `lodash`'s `cloneDeep` won't work as this won't clone functions (which we are using as configuration options in some cases of course). Reusing nested configuration objects would be problematic with this implementation as this only works one level deep.

Another way to approach this could be to simply put a note in the docs that reusing objects is a bad idea in `deploy.js` or for users to create factory methods themselves.
