### PR TITLE
ensure that we start logging from the beginning of the line

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,12 @@ var DeployPluginBase = CoreObject.extend({
     if (!opts.verbose || (opts.verbose && ui.verbose)) {
       if (ui.verbose) {
         ui.write(blue('|    '));
+      } else if (ui.actualOutputStream && ui.actualOutputStream.cursorTo) {
+        // on a real terminal we want to reset the cursor position
+        // to avoid overlap with other outputs
+        ui.actualOutputStream.cursorTo(0);
       }
+
       var chalkColor = chalk[opts.color];
       ui.writeLine(chalkColor('- ' + message));
     }


### PR DESCRIPTION
This is related to https://github.com/ember-cli/ember-cli-deploy/pull/280

In order to ensure proper rendering we need to reset the line position
to 0. This can not be the case if the progress bar is rendering and a
plugin tries to display a log message (i.e. the redis plugin notifying
about the upoaded revision)

/cc @lukemelia 
