### PR TITLE
Bind pluginConfig as 'this' to function property

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ var DeployPluginBase = CoreObject.extend({
   readConfig: function(property){
     var configuredValue = this.pluginConfig[property];
     if (typeof configuredValue === 'function') {
-      return configuredValue.call(this, this.context);
+      return configuredValue.call(this.pluginConfig, this.context);
     }
     return configuredValue;
   },


### PR DESCRIPTION
If I have a `deploy.js` config that does the following:

``` javascript
// config/deploy.js

ENV.foo = {
  bar: function() {
    console.log(this);
  }
}
```

Now, if the `ember-cli-deploy-foo` plugin extends this base plugin, imagine the following code:

``` javascript
upload: function(context) {
  context.foo.bar();
  this.readConfig('bar');
}
```

In this example, in the first call (`context.foo.bar()`), as you would expect, `this` is the containing object - `ENV.foo`. However, in the second call (`this.readConfig('bar')`), `this` is actually the base plugin.

This can lead to confusion and error as `this` will be different based on how it is accessed.

This PR fixes this so that `this` remains the object containing the function which is what you would expect as a consumer of the plugin.
