### PR TITLE
Add plugin helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ module.exports = {
       },
       requiredConfig: ['awesomeApiKey'], // throw an error if this is not configured
 
+      // return an object from here to add functionality to the `pluginHelper`
+      // that is passed in to user defined config property functions
+      pluginHelper: function(context) {
+        return {
+          sayHello: function() {
+            return 'Hello' + context.project.name();
+          }
+        };
+      },
+
       // implement any hooks appropriate for your plugin
       willUpload: function(context) {
         // Use the `readConfig` method for uniform access to this plugin's config,

--- a/README.md
+++ b/README.md
@@ -34,16 +34,6 @@ module.exports = {
       },
       requiredConfig: ['awesomeApiKey'], // throw an error if this is not configured
 
-      // return an object from here to add functionality to the `pluginHelper`
-      // that is passed in to user defined config property functions
-      pluginHelper: function(context) {
-        return {
-          sayHello: function() {
-            return 'Hello' + context.project.name();
-          }
-        };
-      },
-
       // implement any hooks appropriate for your plugin
       willUpload: function(context) {
         // Use the `readConfig` method for uniform access to this plugin's config,

--- a/index.js
+++ b/index.js
@@ -1,5 +1,18 @@
 var CoreObject     = require('core-object');
 var chalk = require('chalk');
+var merge = require('lodash.merge');
+
+function _pluginHelperDefaults() {
+  return {
+    readConfigDefault: function(property) {
+      var configuredValue = this.defaultConfig[property];
+      if (typeof configuredValue === 'function') {
+        return configuredValue.call(this, this.context);
+      }
+      return configuredValue;
+    }.bind(this)
+  };
+}
 
 var DeployPluginBase = CoreObject.extend({
   context: null,
@@ -43,7 +56,8 @@ var DeployPluginBase = CoreObject.extend({
   readConfig: function(property){
     var configuredValue = this.pluginConfig[property];
     if (typeof configuredValue === 'function') {
-      return configuredValue.call(this.pluginConfig, this.context);
+      var helper = merge(this.pluginHelper(this.context), _pluginHelperDefaults.call(this));
+      return configuredValue.call(this.pluginConfig, this.context, helper);
     }
     return configuredValue;
   },
@@ -74,6 +88,10 @@ var DeployPluginBase = CoreObject.extend({
 
       this.logRaw(chalkColor('- ' + message));
     }
+  },
+
+  pluginHelper: function(/*context*/) {
+    return {};
   }
 });
 

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ var DeployPluginBase = CoreObject.extend({
   readConfig: function(property){
     var configuredValue = this.pluginConfig[property];
     if (typeof configuredValue === 'function') {
-      return configuredValue.call(this, this.context);
+      return configuredValue.call(this.pluginConfig, this.context);
     }
     return configuredValue;
   },

--- a/index.js
+++ b/index.js
@@ -1,15 +1,15 @@
 var CoreObject     = require('core-object');
 var chalk = require('chalk');
-var merge = require('lodash.merge');
+var cloneDeep = require('lodash.clonedeep');
 
-function _pluginHelperDefaults() {
+function _pluginHelper() {
   return {
     readConfigDefault: function(property) {
       var configuredValue = this.defaultConfig[property];
       if (typeof configuredValue === 'function') {
-        return configuredValue.call(this, this.context);
+        return cloneDeep(configuredValue.call(this, this.context));
       }
-      return configuredValue;
+      return cloneDeep(configuredValue);
     }.bind(this)
   };
 }
@@ -56,8 +56,7 @@ var DeployPluginBase = CoreObject.extend({
   readConfig: function(property){
     var configuredValue = this.pluginConfig[property];
     if (typeof configuredValue === 'function') {
-      var helper = merge(this.pluginHelper(this.context), _pluginHelperDefaults.call(this));
-      return configuredValue.call(this.pluginConfig, this.context, helper);
+      return configuredValue.call(this.pluginConfig, this.context, _pluginHelper.call(this));
     }
     return configuredValue;
   },
@@ -88,10 +87,6 @@ var DeployPluginBase = CoreObject.extend({
 
       this.logRaw(chalkColor('- ' + message));
     }
-  },
-
-  pluginHelper: function(/*context*/) {
-    return {};
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "chalk": "^1.0.0",
-    "core-object": "0.0.2"
+    "core-object": "0.0.2",
+    "lodash.merge": "^4.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "core-object": "0.0.2",
-    "lodash.merge": "^4.6.0"
+    "lodash.clonedeep": "^4.5.0"
   }
 }

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -75,63 +75,30 @@ describe('base plugin', function() {
   describe('plugin helper', function() {
     it('provides access to the oringal default values', function() {
       var Plugin = Subject.extend({
-        requiredConfig: ['bar'],
         defaultConfig: {
-          foo: function(context) {
-            return context.foo;
-          }
+          distFiles: ['index.html', 'assets/logo.png']
         }
       });
 
       var plugin = new Plugin({
-        name: 'blah'
+        name: 'build'
       });
 
       var context = {
-        foo: 'foo',
         config: {
-          blah: {
-            foo: function(context, pluginHelper) {
-              return pluginHelper.readConfigDefault('foo') + 'foo';
-            },
-            bar: function(context, pluginHelper) {
-              return pluginHelper.readConfigDefault('bar') + 'bar';
+          build: {
+            distFiles: function(context, pluginHelper) {
+              var arr = pluginHelper.readConfigDefault('distFiles');
+              arr.push('index.json');
+              return arr;
             }
           }
         }
       };
 
       plugin.beforeHook(context);
-      assert.equal(plugin.readConfig('foo'), 'foofoo');
-      assert.equal(plugin.readConfig('bar'), 'undefinedbar');
-    });
-
-    it('allows the implementer to add things to the pluginHelper', function() {
-      var Plugin = Subject.extend({
-        defaultConfig: { foo: 'foo' }
-      });
-
-      var plugin = new Plugin({
-        name: 'blah',
-
-        pluginHelper: function(context) {
-          return { bar: context.foo };
-        }
-      });
-
-      var context = {
-        foo: 'bar',
-        config: {
-          blah: {
-            foo: function(context, pluginHelper) {
-              return pluginHelper.readConfigDefault('foo') + pluginHelper.bar;
-            }
-          }
-        }
-      };
-
-      plugin.beforeHook(context);
-      assert.equal(plugin.readConfig('foo'), 'foobar');
+      assert.deepEqual(plugin.defaultConfig.distFiles, ['index.html', 'assets/logo.png']);
+      assert.deepEqual(plugin.readConfig('distFiles'), ['index.html', 'assets/logo.png', 'index.json']);
     });
   });
 });

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -70,7 +70,68 @@ describe('base plugin', function() {
       plugin.log('foo', {verbose: true});
       assert.deepEqual(verboseUi.messages, ['\u001b[34m|    \u001b[39m']);
     });
-
   });
 
+  describe('plugin helper', function() {
+    it('provides access to the oringal default values', function() {
+      var Plugin = Subject.extend({
+        requiredConfig: ['bar'],
+        defaultConfig: {
+          foo: function(context) {
+            return context.foo;
+          }
+        }
+      });
+
+      var plugin = new Plugin({
+        name: 'blah'
+      });
+
+      var context = {
+        foo: 'foo',
+        config: {
+          blah: {
+            foo: function(context, pluginHelper) {
+              return pluginHelper.readConfigDefault('foo') + 'foo';
+            },
+            bar: function(context, pluginHelper) {
+              return pluginHelper.readConfigDefault('bar') + 'bar';
+            }
+          }
+        }
+      };
+
+      plugin.beforeHook(context);
+      assert.equal(plugin.readConfig('foo'), 'foofoo');
+      assert.equal(plugin.readConfig('bar'), 'undefinedbar');
+    });
+
+    it('allows the implementer to add things to the pluginHelper', function() {
+      var Plugin = Subject.extend({
+        defaultConfig: { foo: 'foo' }
+      });
+
+      var plugin = new Plugin({
+        name: 'blah',
+
+        pluginHelper: function(context) {
+          return { bar: context.foo };
+        }
+      });
+
+      var context = {
+        foo: 'bar',
+        config: {
+          blah: {
+            foo: function(context, pluginHelper) {
+              return pluginHelper.readConfigDefault('foo') + pluginHelper.bar;
+            }
+          }
+        }
+      };
+
+      plugin.beforeHook(context);
+      assert.equal(plugin.readConfig('foo'), 'foobar');
+    });
+  });
 });


### PR DESCRIPTION
## Add `pluginHelper` to config property functions

In order to access the default value of a plugin property from within a consumer defined config function, a `pluginHelper` is now passed in like so:

``` javascript
ENV['foo'] = {
  names: function(context, pluginHelper) {
    return pluginHelper.readConfigDefault('distFiles').push('index.json'); #=> ['index.htm', 'index.json']
  }
};
```

## Fix `this` context inside config property functions

If I have a `deploy.js` config that does the following:

``` javascript
// config/deploy.js

ENV.foo = {
  bar: function() {
    console.log(this);
  }
}
```

Now, if the `ember-cli-deploy-foo` plugin extends this base plugin, imagine the following code:

``` javascript
upload: function(context) {
  context.foo.bar();
  this.readConfig('bar');
}
```

In this example, in the first call (`context.foo.bar()`), as you would expect, `this` is the containing object - `ENV.foo`. However, in the second call (`this.readConfig('bar')`), `this` is actually the base plugin.

This can lead to confusion and error as `this` will be different based on how it is accessed.

This PR fixes this so that `this` remains the object containing the function which is what you would expect as a consumer of the plugin.
