### PR TITLE
Add  function to pluginHelper

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,10 @@ function _pluginHelper() {
         return cloneDeep(configuredValue.call(this, this.context));
       }
       return cloneDeep(configuredValue);
+    }.bind(this),
+
+    readConfig: function(property) {
+      return cloneDeep(this.readConfig(property));
     }.bind(this)
   };
 }


### PR DESCRIPTION
This PR will add a `readConfig` function to the `pluginHelper` object that is passed to plugin functions.

This function would be used by plugin authors and users that would like to access the config for the current plugin.  An example of this is as follows:

```javascript
host: 'localhost',
port: 1234,
redisDeployClient: function(context, pluginHelper) {
  var redisLib = context._redisLib;
  var options: {
    host: pluginHelper.readConfig('host'),
    port: pluginHelper.readConfig('port'),
  };

  return new Redis(options, redisLib);
},
```

This is instead of doing the old way:

```javascript
host: 'localhost',
port: 1234,
redisDeployClient: function(context) {
  var redisLib = context._redisLib;
  var options: {
    host: this.readConfig('host'),
    port: this.readConfig('port'),
  };

  return new Redis(options, redisLib);
},
```

which no longer works since [ember-cli-deploy/ember-cli-deploy-plugin#15](https://github.com/ember-cli-deploy/ember-cli-deploy-plugin/pull/15) was introduced.