### PR TITLE
error when creating a plugin without a name

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,12 @@ var DeployPluginBase = CoreObject.extend({
   project: null,
   pluginConfig: null,
   defaultConfig: {},
+  init: function() {
+    this._super.init.apply(this, arguments);
+    if (!this.name) {
+      throw new Error('Plugin is missing name property');
+    }
+  },
   beforeHook: function(context) {
     this.context = context;
     this.ui = context.ui;

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -34,6 +34,14 @@ describe('base plugin', function() {
     assert.equal(plugin.name, 'test-plugin');
   });
 
+  it('errors when no name is set', function() {
+    var makePluginWithNoName = function() {
+      new Subject();
+    };
+
+    assert.throws(makePluginWithNoName, /missing name/);
+  });
+
   describe('log', function() {
 
     it('logs raw', function() {


### PR DESCRIPTION
I inadvertently removed the `name` from my plugin and the error message when running ember-cli-deploy was complaining that a `key` property was missing from within the DAG code.

This raises an error in `init` if no name has been specified