### PR TITLE
Make ember-cli-deploy a runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "core-object": "2.0.6",
+    "ember-cli-deploy": "^1.0.0",
     "lodash.clonedeep": "^4.5.0"
   }
 }


### PR DESCRIPTION
On the off chance that someone installs a plugin without installing ember-cli-deploy, let's make it a runtime dependency of the base plugin. 